### PR TITLE
Add configurable normalization flag to transformer

### DIFF
--- a/model/model.py
+++ b/model/model.py
@@ -12,20 +12,22 @@ class OneLayerTransformer(nn.Module):
     dropout=0.0,
     vocab_size=10,
     max_seq_len=128,
+    use_norm=True,
     ):
         super().__init__()
         self.model_dim = model_dim
         self.num_heads = num_heads
         self.ffn_type = ffn_type
         self.dropout = dropout
+        self.use_norm = use_norm
 
         self.vocab = nn.Embedding(vocab_size, model_dim)
         self.pos_embed = nn.Embedding(max_seq_len, model_dim)
 
-        self.atn_norm = nn.RMSNorm(model_dim)
+        self.atn_norm = nn.RMSNorm(model_dim) if use_norm else nn.Identity()
         self.atn = MHA(d_model=model_dim, num_heads=num_heads, dropout=dropout)
 
-        self.ffn_norm = nn.RMSNorm(model_dim)
+        self.ffn_norm = nn.RMSNorm(model_dim) if use_norm else nn.Identity()
         if ffn_type == "ffn":   
             intermediate_dim = model_dim * 4
             self.ffn = FFN(input_dim=model_dim, intermediate_dim=intermediate_dim, output_dim=model_dim, activation=nn.SiLU)
@@ -35,7 +37,7 @@ class OneLayerTransformer(nn.Module):
         else:
             raise ValueError(f"Invalid FFN type: {ffn_type}")
 
-        self.out_norm = nn.RMSNorm(model_dim)
+        self.out_norm = nn.RMSNorm(model_dim) if use_norm else nn.Identity()
 
 
     def forward(self, x):

--- a/train.py
+++ b/train.py
@@ -138,6 +138,8 @@ def main():
     parser.add_argument('--checkpoint_dir', type=str, default='checkpoints')
     parser.add_argument('--wandb_project', type=str, default='add-7-transformer')
     parser.add_argument('--no_wandb', action='store_true')
+    parser.add_argument('--use_norm', dest='use_norm', action='store_true', default=True, help='Enable RMSNorm layers')
+    parser.add_argument('--no_use_norm', dest='use_norm', action='store_false', help='Disable RMSNorm layers')
     args = parser.parse_args()
 
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
@@ -153,6 +155,7 @@ def main():
         num_heads=args.num_heads,
         ffn_type=args.ffn_type,
         vocab_size=VOCAB_SIZE,
+        use_norm=args.use_norm,
     ).to(device)
 
     print(f"Model parameters: {sum(p.numel() for p in model.parameters()):,}")


### PR DESCRIPTION
## Summary
- add a use_norm flag to OneLayerTransformer to toggle RMSNorm layers with identity fallbacks
- expose CLI switches to enable or disable normalization while keeping it enabled by default

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c13c5b170832ea51d130fbc8c865e)