### PR TITLE
Update README and add parameter counting utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Investigating how different FFN architectures affect what attention learns in a minimal transformer setting.
 
-## Motivation
+## The Add-7 Task
 
 We train a one-layer transformer to add 7 to a number (represented digit-by-digit in reversed order). This task has a simple, well-defined structure:
 
@@ -10,21 +10,38 @@ We train a one-layer transformer to add 7 to a number (represented digit-by-digi
 2. **Second digit:** Add 1 if first digit overflows (>=10)
 3. **All other digits:** Add 1 if there's a carry chain (all preceding digits were 9 and overflowed)
 
-Example: `593 + 7 = 600`
-- Input (reversed): `3 9 5`
-- Output (reversed): `0 0 6`
-- Pattern: 3+7=10 (overflow) -> 9+1=10 (overflow) -> 5+1=6
+**Example:** `593 + 7 = 600`
+```
+Input (reversed):  3 9 5
+Output (reversed): 0 0 6
+Pattern: 3+7=10 (overflow) -> 9+1=10 (overflow) -> 5+1=6
+```
 
 ## Research Question
 
 How does the choice of FFN architecture affect what the attention mechanism learns?
 
-We compare three architectures (matched for parameter count):
-1. **Standard FFN** - Dense feedforward with 4x hidden dimension
-2. **GLU** - Gated Linear Unit
-3. **MoE** - Mixture of Experts (with both FFN and GLU variants)
+We compare three architectures:
+- **Standard FFN** - Dense feedforward with 4x hidden dimension
+- **GLU** - Gated Linear Unit (SwiGLU-style, no bias)
+- **MoE** - Mixture of Experts *(coming soon)*
 
 Inspired by [Yuan et al. (2025)](https://arxiv.org/abs/2506.01115) which analyzes attention patterns in arithmetic tasks.
+
+## Architecture
+
+The `OneLayerTransformer` consists of:
+- Token + positional embeddings
+- Pre-norm multi-head attention (RMSNorm)
+- Pre-norm FFN/GLU
+- Tied output embeddings (weight sharing with input)
+
+Key features:
+- **`use_norm`** flag to enable/disable RMSNorm layers
+- **Causal attention** by default
+- **SiLU activation** in FFN/GLU
+
+Run `uv run python count_params.py` to see parameter breakdown by component.
 
 ## Installation
 
@@ -32,7 +49,11 @@ Inspired by [Yuan et al. (2025)](https://arxiv.org/abs/2506.01115) which analyze
 uv sync
 ```
 
-## Usage
+**Requirements:** Python 3.13+, PyTorch 2.9+
+
+## Training
+
+### Basic Training
 
 ```bash
 # Train with standard FFN
@@ -41,22 +62,28 @@ uv run python train.py --ffn_type ffn --num_digits 2
 # Train with GLU
 uv run python train.py --ffn_type glu --num_digits 2
 
-# Disable wandb for local testing
+# Local testing (no wandb)
 uv run python train.py --no_wandb --patience 3
+```
 
-# Train with register tokens (inspired by "Vision Transformers Need Registers")
+### Register Tokens
+
+Based on [Vision Transformers Need Registers](https://arxiv.org/abs/2309.16588) (Darcet et al., 2024), register tokens provide a "scratch space" for attention.
+
+```bash
+# Train with 1 register token
 uv run python train_with_registers.py --num_registers 1 --num_digits 2
 
-# Train with multiple register tokens
+# Train with multiple registers
 uv run python train_with_registers.py --num_registers 4 --num_digits 2
 ```
 
-### Options
+### CLI Options
 
 | Argument | Default | Description |
 |----------|---------|-------------|
 | `--num_digits` | 2 | Number of input digits |
-| `--num_registers` | 1 | Number of register tokens (train_with_registers.py only) |
+| `--num_registers` | 1 | Register tokens (train_with_registers.py) |
 | `--model_dim` | 64 | Model dimension |
 | `--num_heads` | 4 | Number of attention heads |
 | `--ffn_type` | ffn | FFN type: `ffn` or `glu` |
@@ -69,12 +96,32 @@ uv run python train_with_registers.py --num_registers 4 --num_digits 2
 | `--checkpoint_dir` | checkpoints | Checkpoint directory |
 | `--no_wandb` | False | Disable wandb logging |
 
-## Analysis Notebooks
+## Interpretability
 
-The project includes [Marimo](https://marimo.io/) notebooks for interpretability analysis:
+### FormerLens
+
+A TransformerLens-compatible library for capturing intermediate activations:
+
+```python
+from formerlens import HookedOneLayerTransformer
+
+# Load from checkpoint
+model = HookedOneLayerTransformer.from_checkpoint("checkpoints/best_model.pt")
+
+# Run with activation cache
+logits, cache = model.run_with_cache(tokens)
+
+# Access activations
+attn_pattern = cache["atn.hook_pattern"]
+ffn_activations = cache["ffn.hook_post_act"]
+```
+
+### Analysis Notebooks
+
+[Marimo](https://marimo.io/) notebooks for interactive analysis:
 
 ```bash
-# FFN activation analysis for digit overflow patterns
+# FFN activation analysis - digit overflow patterns
 uv run marimo edit ffn_activation_analysis.py
 
 # TransformerLens-based activation analysis
@@ -84,19 +131,38 @@ uv run marimo edit tl_activation_analysis.py
 uv run marimo edit captum_demo.py
 ```
 
+Jupyter notebook: `attention_analysis.ipynb`
+
 ## Project Structure
 
 ```
+moe-expressivity/
 ├── model/
-│   ├── components.py          # MHA, FFN, GLU implementations
-│   └── model.py               # OneLayerTransformer
-├── train.py                   # Training script
-├── train_with_registers.py    # Training with register tokens
-├── ffn_activation_analysis.py # FFN activation patterns (Marimo)
-├── tl_activation_analysis.py  # TransformerLens analysis (Marimo)
-├── captum_demo.py             # Captum interpretability demo (Marimo)
-└── checkpoints/               # Saved models
+│   ├── components.py           # MHA, FFN, GLU implementations
+│   └── model.py                # OneLayerTransformer
+├── formerlens/
+│   ├── __init__.py             # Public API
+│   ├── hooked_components.py    # Hooked MHA, FFN, GLU
+│   └── hooked_former.py        # HookedOneLayerTransformer
+├── train.py                    # Basic training script
+├── train_with_registers.py     # Training with register tokens
+├── count_params.py             # Parameter counting utility
+├── ffn_activation_analysis.py  # Marimo: FFN analysis
+├── tl_activation_analysis.py   # Marimo: TransformerLens analysis
+├── captum_demo.py              # Marimo: Captum demo
+├── attention_analysis.ipynb    # Jupyter: attention patterns
+└── checkpoints/                # Saved models
 ```
+
+## Dependencies
+
+- **torch** - Core deep learning
+- **wandb** - Experiment tracking
+- **transformer-lens** - Mechanistic interpretability
+- **captum** - PyTorch interpretability
+- **marimo** - Reactive notebooks
+- **matplotlib** - Visualization
+- **circuitsvis** - Attention visualization
 
 ## Status
 

--- a/count_params.py
+++ b/count_params.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env -S uv run
+"""Script to count and display parameters for each component of OneLayerTransformer."""
+
+import torch
+import sys
+sys.path.insert(0, 'model')
+
+from model import OneLayerTransformer
+
+
+def count_parameters(module):
+    """Count total parameters in a module."""
+    return sum(p.numel() for p in module.parameters())
+
+
+def count_trainable_parameters(module):
+    """Count trainable parameters in a module."""
+    return sum(p.numel() for p in module.parameters() if p.requires_grad)
+
+
+def format_params(n):
+    """Format parameter count with commas and human-readable suffix."""
+    if n >= 1_000_000:
+        return f"{n:,} ({n/1_000_000:.2f}M)"
+    elif n >= 1_000:
+        return f"{n:,} ({n/1_000:.2f}K)"
+    return f"{n:,}"
+
+
+def analyze_model(model_dim=256, num_heads=8, ffn_type="ffn", vocab_size=10, max_seq_len=128):
+    """Analyze parameter counts for OneLayerTransformer."""
+
+    print("=" * 70)
+    print(f"OneLayerTransformer Parameter Analysis")
+    print("=" * 70)
+    print(f"\nConfiguration:")
+    print(f"  model_dim:    {model_dim}")
+    print(f"  num_heads:    {num_heads}")
+    print(f"  ffn_type:     {ffn_type}")
+    print(f"  vocab_size:   {vocab_size}")
+    print(f"  max_seq_len:  {max_seq_len}")
+    print()
+
+    model = OneLayerTransformer(
+        model_dim=model_dim,
+        num_heads=num_heads,
+        ffn_type=ffn_type,
+        vocab_size=vocab_size,
+        max_seq_len=max_seq_len,
+    )
+
+    # Component breakdown
+    components = {
+        "vocab (token embedding)": model.vocab,
+        "pos_embed (positional embedding)": model.pos_embed,
+        "atn_norm (pre-attention RMSNorm)": model.atn_norm,
+        "atn (multi-head attention)": model.atn,
+        "ffn_norm (pre-FFN RMSNorm)": model.ffn_norm,
+        f"ffn ({ffn_type.upper()})": model.ffn,
+        "out_norm (output RMSNorm)": model.out_norm,
+    }
+
+    print("-" * 70)
+    print(f"{'Component':<40} {'Parameters':>25}")
+    print("-" * 70)
+
+    total = 0
+    for name, module in components.items():
+        params = count_parameters(module)
+        total += params
+        print(f"{name:<40} {format_params(params):>25}")
+
+    print("-" * 70)
+    print(f"{'TOTAL':<40} {format_params(total):>25}")
+    print("-" * 70)
+
+    # Detailed breakdown for attention
+    print("\n" + "=" * 70)
+    print("Attention (MHA) Breakdown:")
+    print("-" * 70)
+    atn_components = {
+        "q_proj": model.atn.q_proj,
+        "k_proj": model.atn.k_proj,
+        "v_proj": model.atn.v_proj,
+        "o_proj": model.atn.o_proj,
+    }
+    for name, module in atn_components.items():
+        params = count_parameters(module)
+        print(f"  {name:<36} {format_params(params):>25}")
+
+    # Detailed breakdown for FFN
+    print("\n" + "=" * 70)
+    print(f"FFN ({ffn_type.upper()}) Breakdown:")
+    print("-" * 70)
+    if ffn_type == "ffn":
+        ffn_components = {
+            "up_proj": model.ffn.up_proj,
+            "down_proj": model.ffn.down_proj,
+        }
+    else:  # glu
+        ffn_components = {
+            "gate_proj": model.ffn.gate_proj,
+            "up_proj": model.ffn.up_proj,
+            "down_proj": model.ffn.down_proj,
+        }
+    for name, module in ffn_components.items():
+        params = count_parameters(module)
+        print(f"  {name:<36} {format_params(params):>25}")
+
+    # Parameter distribution
+    print("\n" + "=" * 70)
+    print("Parameter Distribution:")
+    print("-" * 70)
+
+    categories = {
+        "Embeddings": count_parameters(model.vocab) + count_parameters(model.pos_embed),
+        "Attention": count_parameters(model.atn),
+        "FFN": count_parameters(model.ffn),
+        "Normalization": (count_parameters(model.atn_norm) +
+                         count_parameters(model.ffn_norm) +
+                         count_parameters(model.out_norm)),
+    }
+
+    for name, params in categories.items():
+        pct = 100 * params / total
+        bar = "#" * int(pct / 2)
+        print(f"  {name:<15} {format_params(params):>20} ({pct:5.1f}%) {bar}")
+
+    print("\n")
+    return model
+
+
+if __name__ == "__main__":
+    # Default analysis
+    print("\n" + "=" * 70)
+    print("ANALYSIS WITH FFN")
+    analyze_model(ffn_type="ffn")
+
+    print("\n" + "=" * 70)
+    print("ANALYSIS WITH GLU")
+    analyze_model(ffn_type="glu")


### PR DESCRIPTION
## Summary
- Comprehensive README rewrite with improved structure and documentation
- Add `count_params.py` utility for analyzing parameter distribution by component
- Document FormerLens interpretability library with usage examples
- Add Architecture section explaining OneLayerTransformer design
- Document register tokens training with paper reference

## Changes
- **README.md**: Full rewrite with better organization, FormerLens docs, architecture details, dependencies list
- **count_params.py**: New utility that shows parameter breakdown for each transformer component (embeddings, attention, FFN, normalization)

## Test plan
- [x] `uv run python count_params.py` runs successfully
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)